### PR TITLE
fix(index): validate and sanitize json objects and strings correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
 		"@types/lodash": "^4.14.162",
 		"@types/node": "^14.11.10",
 		"@types/sanitize-html": "^1.27.0",
+		"@types/serialize-javascript": "^4.0.0",
 		"@typescript-eslint/eslint-plugin": "^4.4.1",
 		"@typescript-eslint/parser": "^4.4.1",
 		"conventional-changelog-cli": "^2.1.0",
@@ -90,6 +91,7 @@
 	},
 	"dependencies": {
 		"sanitize-html": "^2.1.0",
+		"serialize-javascript": "^5.0.1",
 		"validator": "^13.1.17",
 		"xss": "^1.0.8"
 	}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -9,31 +9,35 @@ interface LooseObject {
 }
 
 const args: LooseObject = {
+	argArray: ['../', '/../secret.txt'],
+	argArrayString: '["../", "/../secret.txt"]',
 	argBoolean: faker.random.boolean(),
 	argBooleanString: faker.random.boolean().toString(),
 	argCtrlChars: '\x01\x09',
 	argDate: faker.date.past().toISOString().split('T')[0],
 	argHtml: `<a href='https://www.nhs.uk/'><c>b</c></a>`,
 	argInvalid: faker.random.words(5),
-	argJson: '{ "test1": 1, "test2": 2 }',
 	argNumber: faker.random.number(),
 	argNumberString: faker.random.number().toString(),
-	argObject: { test1: faker.random.number(), test2: faker.random.number() },
+	argObject: { test1: faker.random.number(), haxorXSS: '<script></script>' },
+	argObjectString: '{ "test1": 1, "haxorXSS": "<script></script>"}',
 	argPhoneNumber: faker.phone.phoneNumber(),
 	argString: faker.random.word().substring(0, 5),
 	argUkPhoneNumber: '01935475122'
 };
 
 const requiredArgs: LooseObject = {
+	argArray: { type: 'object', mandatory: false },
+	argArrayString: { type: 'string', mandatory: false },
 	argBoolean: { type: 'boolean', mandatory: false },
 	argBooleanString: { type: 'boolean', mandatory: false },
 	argCtrlChars: { type: 'string' },
 	argDate: { type: 'date', mandatory: false },
 	argHtml: { type: 'string' },
-	argJson: { type: 'json', mandatory: false },
 	argNumber: { type: 'number', mandatory: false },
 	argNumberString: { type: 'number', mandatory: false },
 	argObject: { type: 'object', mandatory: false },
+	argObjectString: { type: 'object', mandatory: false},
 	argPhoneNumber: { type: 'string', mandatory: false },
 	argString: { type: 'string', mandatory: false, maxLength: 5 },
 	argUkPhoneNumber: { type: 'string', mandatory: false }
@@ -59,6 +63,8 @@ describe('Sanitization and validation middleware', () => {
 		middleware(req, res, next);
 
 		expect(req.query).toMatchObject({
+			argArray: expect.any(String),
+			argArrayString: expect.any(String),
 			argBoolean: expect.any(Boolean),
 			argBooleanString: expect.any(Boolean),
 			argCtrlChars: '',
@@ -66,7 +72,8 @@ describe('Sanitization and validation middleware', () => {
 			argHtml: '<a href="https://www.nhs.uk/">b</a>',
 			argNumber: expect.any(Number),
 			argNumberString: expect.any(Number),
-			argObject: expect.any(Object),
+			argObject: expect.any(String),
+			argObjectString: expect.any(String),
 			argPhoneNumber: expect.any(String),
 			argString: expect.any(String),
 			argUkPhoneNumber: expect.any(String)
@@ -90,6 +97,8 @@ describe('Sanitization and validation middleware', () => {
 		middleware(req, res, next);
 
 		expect(req.query).toMatchObject({
+			argArray: expect.any(String),
+			argArrayString: expect.any(String),
 			argBoolean: expect.any(Boolean),
 			argBooleanString: expect.any(Boolean),
 			argCtrlChars: '',
@@ -97,7 +106,8 @@ describe('Sanitization and validation middleware', () => {
 			argHtml: '<a href="https://www.nhs.uk/">b</a>',
 			argNumber: expect.any(Number),
 			argNumberString: expect.any(Number),
-			argObject: expect.any(Object),
+			argObject: expect.any(String),
+			argObjectString: expect.any(String),
 			argPhoneNumber: expect.any(String),
 			argString: expect.any(String),
 			argUkPhoneNumber: expect.any(String)
@@ -139,6 +149,8 @@ describe('Sanitization and validation middleware', () => {
 		middleware(req, res, next);
 
 		expect(req.params).toMatchObject({
+			argArray: expect.any(String),
+			argArrayString: expect.any(String),
 			argBoolean: expect.any(Boolean),
 			argBooleanString: expect.any(Boolean),
 			argCtrlChars: '',
@@ -146,7 +158,8 @@ describe('Sanitization and validation middleware', () => {
 			argHtml: '<a href="https://www.nhs.uk/">b</a>',
 			argNumber: expect.any(Number),
 			argNumberString: expect.any(Number),
-			argObject: expect.any(Object),
+			argObject: expect.any(String),
+			argObjectString: expect.any(String),
 			argPhoneNumber: expect.any(String),
 			argString: expect.any(String),
 			argUkPhoneNumber: expect.any(String)
@@ -188,6 +201,8 @@ describe('Sanitization and validation middleware', () => {
 		middleware(req, res, next);
 
 		expect(req.body).toMatchObject({
+			argArray: expect.any(String),
+			argArrayString: expect.any(String),
 			argBoolean: expect.any(Boolean),
 			argBooleanString: expect.any(Boolean),
 			argCtrlChars: '',
@@ -195,7 +210,8 @@ describe('Sanitization and validation middleware', () => {
 			argHtml: '<a href="https://www.nhs.uk/">b</a>',
 			argNumber: expect.any(Number),
 			argNumberString: expect.any(Number),
-			argObject: expect.any(Object),
+			argObject: expect.any(String),
+			argObjectString: expect.any(String),
 			argPhoneNumber: expect.any(String),
 			argString: expect.any(String),
 			argUkPhoneNumber: expect.any(String)

--- a/yarn.lock
+++ b/yarn.lock
@@ -693,6 +693,11 @@
   dependencies:
     htmlparser2 "^4.1.0"
 
+"@types/serialize-javascript@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/serialize-javascript/-/serialize-javascript-4.0.0.tgz#ab9c47edf71f6a4590221118d1dffc37b50d71a2"
+  integrity sha512-y9UO8ozDGF30EVRizmsXuCdZzAxHmYpEEiL+/SQjX+7bnxslkvZQU8rLydixJv7yVae6bWyrNDFHsh6fYHkFMA==
+
 "@types/serve-static@*":
   version "1.13.5"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.5.tgz#3d25d941a18415d3ab092def846e135a08bbcf53"
@@ -4736,6 +4741,13 @@ quick-lru@^4.0.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
   integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
 
+randombytes@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
+  integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
+  dependencies:
+    safe-buffer "^5.1.0"
+
 range-parser@^1.2.0, range-parser@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
@@ -5039,7 +5051,7 @@ safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
+safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -5124,6 +5136,13 @@ send@0.17.1:
     on-finished "~2.3.0"
     range-parser "~1.2.1"
     statuses "~1.5.0"
+
+serialize-javascript@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-5.0.1.tgz#7886ec848049a462467a97d3d918ebb2aaf934f4"
+  integrity sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==
+  dependencies:
+    randombytes "^2.1.0"
 
 serve-static@1.14.1:
   version "1.14.1"


### PR DESCRIPTION
BREAKING CHANGE: removed `json` type, use `object` or `string` instead. Middleware no longer returns objects or JSON, only serialised strings of them.